### PR TITLE
四則演算子のタップ時の処理を1メソッドに寄せる

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
         <activity
-            android:name=".view.CalculatorActivity"
+            android:name=".views.CalculatorActivity"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/hotatekaoru/kotlincalculator/enums/OperationType.kt
+++ b/app/src/main/java/com/hotatekaoru/kotlincalculator/enums/OperationType.kt
@@ -1,13 +1,13 @@
 package com.hotatekaoru.kotlincalculator.enums
 
-enum class OperationTypeEnum(val label: String) {
+enum class OperationType(val label: String) {
     PLUS("+") { override fun calc(x: Double, y: Double): Double = x + y },
     MINUS("-") { override fun calc(x: Double, y: Double): Double = x - y },
     MULTIPLE("×") { override fun calc(x: Double, y: Double): Double = x * y },
     DIVIDE("÷") { override fun calc(x: Double, y: Double): Double = x / y };
 
     companion object {
-        fun isPlusOrMinus(enum: OperationTypeEnum): Boolean {
+        fun isPlusOrMinus(enum: OperationType): Boolean {
             return PLUS == enum || MINUS == enum
         }
     }

--- a/app/src/main/java/com/hotatekaoru/kotlincalculator/enums/OperationTypeEnum.kt
+++ b/app/src/main/java/com/hotatekaoru/kotlincalculator/enums/OperationTypeEnum.kt
@@ -1,4 +1,4 @@
-package com.hotatekaoru.kotlincalculator.enum
+package com.hotatekaoru.kotlincalculator.enums
 
 enum class OperationTypeEnum(val label: String) {
     PLUS("+") { override fun calc(x: Double, y: Double): Double = x + y },

--- a/app/src/main/java/com/hotatekaoru/kotlincalculator/extensions/ExtObservableField.kt
+++ b/app/src/main/java/com/hotatekaoru/kotlincalculator/extensions/ExtObservableField.kt
@@ -1,4 +1,4 @@
-package com.hotatekaoru.kotlincalculator.extension
+package com.hotatekaoru.kotlincalculator.extensions
 
 import androidx.databinding.ObservableField
 

--- a/app/src/main/java/com/hotatekaoru/kotlincalculator/models/Calculator.kt
+++ b/app/src/main/java/com/hotatekaoru/kotlincalculator/models/Calculator.kt
@@ -1,6 +1,6 @@
 package com.hotatekaoru.kotlincalculator.models
 
-import com.hotatekaoru.kotlincalculator.enums.OperationTypeEnum
+import com.hotatekaoru.kotlincalculator.enums.OperationType
 
 // 計算式に関するロジックは、Wikiに記載
 // https://github.com/hotatekaoru/KotlinCalculator/wiki/Logic-of-Calculator
@@ -9,7 +9,7 @@ class Calculator {
 
     private val numberStringList = ArrayList<String>()
     private val numberList = ArrayList<Double>()
-    private val operationList = ArrayList<OperationTypeEnum>()
+    private val operationList = ArrayList<OperationType>()
 
     fun call(formula: String): Double {
         this.formula = formula
@@ -69,10 +69,10 @@ class Calculator {
                 else -> {
                     // 最初にマイナスから始まる場合は、最初に0があたかもあるかのようにする。
                     // これにより、numberList[0]のあとに、operationList[0]がある状態を作る
-                    if (OperationTypeEnum.MINUS.label == char.toString() && numberStringList.isEmpty()) {
+                    if (OperationType.MINUS.label == char.toString() && numberStringList.isEmpty()) {
                         numberStringList.add("0")
                     }
-                    OperationTypeEnum.values().firstOrNull { it.label == char.toString() }?.let {
+                    OperationType.values().firstOrNull { it.label == char.toString() }?.let {
                         operationList.add(it)
                     }
                     isLastCharOperation = true
@@ -83,7 +83,7 @@ class Calculator {
 
     private fun convertToNumberList() {
         for ((index, string) in numberStringList.withIndex()) {
-            if (index == 0 || OperationTypeEnum.MINUS != operationList[index - 1]) {
+            if (index == 0 || OperationType.MINUS != operationList[index - 1]) {
                 numberList.add(string.toDouble())
             } else {
                 numberList.add(string.toDouble() * -1)
@@ -93,7 +93,7 @@ class Calculator {
 
     private fun calcMultiplicationAndDivision() {
         for ((index, operation) in operationList.withIndex()) {
-            if (OperationTypeEnum.isPlusOrMinus(operation)) { continue }
+            if (OperationType.isPlusOrMinus(operation)) { continue }
 
             val value = operation.calc(numberList[index], numberList[index + 1])
             numberList[index] = 0.0

--- a/app/src/main/java/com/hotatekaoru/kotlincalculator/models/Calculator.kt
+++ b/app/src/main/java/com/hotatekaoru/kotlincalculator/models/Calculator.kt
@@ -1,6 +1,6 @@
-package com.hotatekaoru.kotlincalculator.model
+package com.hotatekaoru.kotlincalculator.models
 
-import com.hotatekaoru.kotlincalculator.enum.OperationTypeEnum
+import com.hotatekaoru.kotlincalculator.enums.OperationTypeEnum
 
 // 計算式に関するロジックは、Wikiに記載
 // https://github.com/hotatekaoru/KotlinCalculator/wiki/Logic-of-Calculator

--- a/app/src/main/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModel.kt
+++ b/app/src/main/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModel.kt
@@ -3,7 +3,7 @@ package com.hotatekaoru.kotlincalculator.viewmodels
 import androidx.databinding.ObservableBoolean
 import androidx.databinding.ObservableField
 import androidx.lifecycle.ViewModel
-import com.hotatekaoru.kotlincalculator.enums.OperationTypeEnum
+import com.hotatekaoru.kotlincalculator.enums.OperationType
 import com.hotatekaoru.kotlincalculator.extensions.minusLastCharacter
 import com.hotatekaoru.kotlincalculator.extensions.plus
 import com.hotatekaoru.kotlincalculator.extensions.takeLast
@@ -51,7 +51,7 @@ class CalculatorViewModel : ViewModel() {
      */
     fun tapDot() {
         mainValueText.get()?.let { text ->
-            val operationIndex = text.lastIndexOfAny(OperationTypeEnum.values().map { it.label })
+            val operationIndex = text.lastIndexOfAny(OperationType.values().map { it.label })
             if (text.substring(operationIndex + 1).contains(".")) { return }
         }
 
@@ -70,16 +70,16 @@ class CalculatorViewModel : ViewModel() {
     fun tapPlus() {
         if (mainValueText.get().isNullOrBlank()) { return }
         if (mainValueText.takeLast(1) == ".") { return }
-        if (mainValueText.get() != null && mainValueText.get().equals(OperationTypeEnum.MINUS.label)) {
+        if (mainValueText.get() != null && mainValueText.get().equals(OperationType.MINUS.label)) {
             mainValueText.set("")
             calculating.set(false)
             return
         }
 
-        if (OperationTypeEnum.values().any { it.label == mainValueText.takeLast(1) }) {
+        if (OperationType.values().any { it.label == mainValueText.takeLast(1) }) {
             mainValueText.minusLastCharacter()
         }
-        mainValueText.plus(OperationTypeEnum.PLUS.label)
+        mainValueText.plus(OperationType.PLUS.label)
         calculating.set(true)
     }
 
@@ -91,10 +91,10 @@ class CalculatorViewModel : ViewModel() {
      */
     fun tapMinus() {
         if (mainValueText.takeLast(1) == ".") { return }
-        if (OperationTypeEnum.values().any { it.label == mainValueText.takeLast(1) }) {
+        if (OperationType.values().any { it.label == mainValueText.takeLast(1) }) {
             mainValueText.minusLastCharacter()
         }
-        mainValueText.plus(OperationTypeEnum.MINUS.label)
+        mainValueText.plus(OperationType.MINUS.label)
         calculating.set(true)
     }
 
@@ -109,16 +109,16 @@ class CalculatorViewModel : ViewModel() {
     fun tapMultiple() {
         if (mainValueText.get().isNullOrBlank()) { return }
         if (mainValueText.takeLast(1) == ".") { return }
-        if (mainValueText.get() != null && mainValueText.get().equals(OperationTypeEnum.MINUS.label)) {
+        if (mainValueText.get() != null && mainValueText.get().equals(OperationType.MINUS.label)) {
             mainValueText.set("")
             calculating.set(false)
             return
         }
 
-        if (OperationTypeEnum.values().any { it.label == mainValueText.takeLast(1) }) {
+        if (OperationType.values().any { it.label == mainValueText.takeLast(1) }) {
             mainValueText.minusLastCharacter()
         }
-        mainValueText.plus(OperationTypeEnum.MULTIPLE.label)
+        mainValueText.plus(OperationType.MULTIPLE.label)
         calculating.set(true)
     }
 
@@ -133,16 +133,16 @@ class CalculatorViewModel : ViewModel() {
     fun tapDivide() {
         if (mainValueText.get().isNullOrBlank()) { return }
         if (mainValueText.takeLast(1) == ".") { return }
-        if (mainValueText.get() != null && mainValueText.get().equals(OperationTypeEnum.MINUS.label)) {
+        if (mainValueText.get() != null && mainValueText.get().equals(OperationType.MINUS.label)) {
             mainValueText.set("")
             calculating.set(false)
             return
         }
 
-        if (OperationTypeEnum.values().any { it.label == mainValueText.takeLast(1) }) {
+        if (OperationType.values().any { it.label == mainValueText.takeLast(1) }) {
             mainValueText.minusLastCharacter()
         }
-        mainValueText.plus(OperationTypeEnum.DIVIDE.label)
+        mainValueText.plus(OperationType.DIVIDE.label)
         calculating.set(true)
     }
 

--- a/app/src/main/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModel.kt
+++ b/app/src/main/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModel.kt
@@ -1,13 +1,13 @@
-package com.hotatekaoru.kotlincalculator.viewmodel
+package com.hotatekaoru.kotlincalculator.viewmodels
 
 import androidx.databinding.ObservableBoolean
 import androidx.databinding.ObservableField
 import androidx.lifecycle.ViewModel
-import com.hotatekaoru.kotlincalculator.enum.OperationTypeEnum
-import com.hotatekaoru.kotlincalculator.extension.minusLastCharacter
-import com.hotatekaoru.kotlincalculator.extension.plus
-import com.hotatekaoru.kotlincalculator.extension.takeLast
-import com.hotatekaoru.kotlincalculator.model.Calculator
+import com.hotatekaoru.kotlincalculator.enums.OperationTypeEnum
+import com.hotatekaoru.kotlincalculator.extensions.minusLastCharacter
+import com.hotatekaoru.kotlincalculator.extensions.plus
+import com.hotatekaoru.kotlincalculator.extensions.takeLast
+import com.hotatekaoru.kotlincalculator.models.Calculator
 
 class CalculatorViewModel : ViewModel() {
 

--- a/app/src/main/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModel.kt
+++ b/app/src/main/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModel.kt
@@ -60,6 +60,18 @@ class CalculatorViewModel : ViewModel() {
     }
 
     /**
+     * 四則演算子をタップされた際の処理
+     */
+    fun tapOperation(operationType: OperationType) {
+        when (operationType) {
+            OperationType.PLUS -> { tapPlus() }
+            OperationType.MINUS -> { tapMinus() }
+            OperationType.MULTIPLE -> { tapMultiple() }
+            OperationType.DIVIDE -> { tapDivide() }
+        }
+    }
+
+    /**
      * +をタップされた際の処理
      * mainValueTextが空の場合、return
      * mainValueTextの末尾が.の場合、return
@@ -67,7 +79,7 @@ class CalculatorViewModel : ViewModel() {
      * mainValueTextの末尾が四則演算子の場合、+に入れ替える
      * 上記以外の場合、mainValueTextの末尾に+を追加
      */
-    fun tapPlus() {
+    private fun tapPlus() {
         if (mainValueText.get().isNullOrBlank()) { return }
         if (mainValueText.takeLast(1) == ".") { return }
         if (mainValueText.get() != null && mainValueText.get().equals(OperationType.MINUS.label)) {
@@ -89,7 +101,7 @@ class CalculatorViewModel : ViewModel() {
      * mainValueTextの末尾が四則演算子の場合、-に入れ替える
      * 上記以外の場合、mainValueTextの末尾に-を追加
      */
-    fun tapMinus() {
+    private fun tapMinus() {
         if (mainValueText.takeLast(1) == ".") { return }
         if (OperationType.values().any { it.label == mainValueText.takeLast(1) }) {
             mainValueText.minusLastCharacter()
@@ -106,7 +118,7 @@ class CalculatorViewModel : ViewModel() {
      * mainValueTextの末尾が四則演算子の場合、×に入れ替える
      * 上記以外の場合、mainValueTextの末尾に×を追加
      */
-    fun tapMultiple() {
+    private fun tapMultiple() {
         if (mainValueText.get().isNullOrBlank()) { return }
         if (mainValueText.takeLast(1) == ".") { return }
         if (mainValueText.get() != null && mainValueText.get().equals(OperationType.MINUS.label)) {
@@ -130,7 +142,7 @@ class CalculatorViewModel : ViewModel() {
      * mainValueTextの末尾が四則演算子の場合、÷に入れ替える
      * 上記以外の場合、mainValueTextの末尾に÷を追加
      */
-    fun tapDivide() {
+    private fun tapDivide() {
         if (mainValueText.get().isNullOrBlank()) { return }
         if (mainValueText.takeLast(1) == ".") { return }
         if (mainValueText.get() != null && mainValueText.get().equals(OperationType.MINUS.label)) {

--- a/app/src/main/java/com/hotatekaoru/kotlincalculator/views/CalculatorActivity.kt
+++ b/app/src/main/java/com/hotatekaoru/kotlincalculator/views/CalculatorActivity.kt
@@ -1,4 +1,4 @@
-package com.hotatekaoru.kotlincalculator.view
+package com.hotatekaoru.kotlincalculator.views
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -6,7 +6,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProviders
 import com.hotatekaoru.kotlincalculator.R
 import com.hotatekaoru.kotlincalculator.databinding.ActivityCalculatorBinding
-import com.hotatekaoru.kotlincalculator.viewmodel.CalculatorViewModel
+import com.hotatekaoru.kotlincalculator.viewmodels.CalculatorViewModel
 
 class CalculatorActivity : AppCompatActivity() {
 

--- a/app/src/main/res/layout/activity_calculator.xml
+++ b/app/src/main/res/layout/activity_calculator.xml
@@ -3,16 +3,20 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <data>
+    <data class="ActivityCalculatorBinding">
         <variable
             name="viewmodel"
-            type="com.hotatekaoru.kotlincalculator.viewmodel.CalculatorViewModel" />
+            type="com.hotatekaoru.kotlincalculator.viewmodels.CalculatorViewModel" />
+
+        <variable
+            name="operationType"
+            type="com.hotatekaoru.kotlincalculator.enums.OperationTypeEnum" />
     </data>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".view.CalculatorActivity">
+        tools:context=".views.CalculatorActivity">
 
         <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_calculator.xml
+++ b/app/src/main/res/layout/activity_calculator.xml
@@ -10,7 +10,7 @@
 
         <variable
             name="operationType"
-            type="com.hotatekaoru.kotlincalculator.enums.OperationTypeEnum" />
+            type="com.hotatekaoru.kotlincalculator.enums.OperationType" />
     </data>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout

--- a/app/src/main/res/layout/activity_calculator.xml
+++ b/app/src/main/res/layout/activity_calculator.xml
@@ -230,32 +230,32 @@
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
                         android:layout_weight="1"
-                        android:text="@string/divide"
-                        android:onClick="@{() -> viewmodel.tapDivide()}" />
+                        android:text="@{operationType.DIVIDE.label}"
+                        android:onClick="@{() -> viewmodel.tapOperation(operationType.DIVIDE)}" />
 
                     <Button
                         style="@style/KeyBoardFormulaButton"
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
                         android:layout_weight="1"
-                        android:text="@string/multiple"
-                        android:onClick="@{() -> viewmodel.tapMultiple()}" />
+                        android:text="@{operationType.MULTIPLE.label}"
+                        android:onClick="@{() -> viewmodel.tapOperation(operationType.MULTIPLE)}" />
 
                     <Button
                         style="@style/KeyBoardFormulaButton"
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
                         android:layout_weight="1"
-                        android:text="@string/minus"
-                        android:onClick="@{() -> viewmodel.tapMinus()}" />
+                        android:text="@{operationType.MINUS.label}"
+                        android:onClick="@{() -> viewmodel.tapOperation(operationType.MINUS)}" />
 
                     <Button
                         style="@style/KeyBoardFormulaButton"
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
                         android:layout_weight="1"
-                        android:text="@string/plus"
-                        android:onClick="@{() -> viewmodel.tapPlus()}" />
+                        android:text="@{operationType.PLUS.label}"
+                        android:onClick="@{() -> viewmodel.tapOperation(operationType.PLUS)}" />
 
                 </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,10 +13,6 @@
     <string name="nine">9</string>
     <string name="dot">.</string>
     <string name="equal">=</string>
-    <string name="plus">+</string>
-    <string name="minus">-</string>
-    <string name="multiple">×</string>
-    <string name="divide">÷</string>
     <string name="clear">C</string>
     <string name="delete">⌫</string>
 </resources>

--- a/app/src/test/java/com/hotatekaoru/kotlincalculator/models/CalculatorTest.kt
+++ b/app/src/test/java/com/hotatekaoru/kotlincalculator/models/CalculatorTest.kt
@@ -1,4 +1,4 @@
-package com.hotatekaoru.kotlincalculator.model
+package com.hotatekaoru.kotlincalculator.models
 
 import org.junit.Before
 import org.junit.Test

--- a/app/src/test/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.hotatekaoru.kotlincalculator.viewmodels
 
+import com.hotatekaoru.kotlincalculator.enums.OperationType
 import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.Assertions
@@ -63,28 +64,28 @@ class CalculatorViewModelTest {
     @Test
     fun `tapPlus() mainValueTextが空の場合、mainValueTextが更新されないこと`() {
         viewModel.mainValueText.set("")
-        viewModel.tapPlus()
+        viewModel.tapOperation(OperationType.PLUS)
         Assertions.assertEquals("", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapPlus() mainValueTextの末尾が小数点の場合、mainValueTextが更新されないこと`() {
         viewModel.mainValueText.set("1.")
-        viewModel.tapPlus()
+        viewModel.tapOperation(OperationType.PLUS)
         Assertions.assertEquals("1.", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapPlus() mainValueTextが-のみの場合、mainValueTextが空に更新されること`() {
         viewModel.mainValueText.set("-")
-        viewModel.tapPlus()
+        viewModel.tapOperation(OperationType.PLUS)
         Assertions.assertEquals("", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapPlus() mainValueTextの末尾が四則演算子の場合、末尾の四則演算子が+に入れ替わること`() {
         viewModel.mainValueText.set("1-")
-        viewModel.tapPlus()
+        viewModel.tapOperation(OperationType.PLUS)
         Assertions.assertEquals("1+", viewModel.mainValueText.get())
         Assertions.assertTrue(viewModel.calculating.get())
     }
@@ -92,7 +93,7 @@ class CalculatorViewModelTest {
     @Test
     fun `tapPlus() 上記以外の場合、mainValueTextの末尾に+を追加こと`() {
         viewModel.mainValueText.set("1")
-        viewModel.tapPlus()
+        viewModel.tapOperation(OperationType.PLUS)
         Assertions.assertEquals("1+", viewModel.mainValueText.get())
         Assertions.assertTrue(viewModel.calculating.get())
     }
@@ -100,21 +101,21 @@ class CalculatorViewModelTest {
     @Test
     fun `tapMinus() mainValueTextの末尾が小数点の場合、mainValueTextが更新されないこと`() {
         viewModel.mainValueText.set("1.")
-        viewModel.tapMinus()
+        viewModel.tapOperation(OperationType.MINUS)
         Assertions.assertEquals("1.", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapMinus() mainValueTextの末尾が四則演算子の場合、末尾の四則演算子が-に入れ替わること`() {
         viewModel.mainValueText.set("1÷")
-        viewModel.tapMinus()
+        viewModel.tapOperation(OperationType.MINUS)
         Assertions.assertEquals("1-", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapMinus() 上記以外の場合、mainValueTextの末尾に-が追加されること`() {
         viewModel.mainValueText.set("1")
-        viewModel.tapMinus()
+        viewModel.tapOperation(OperationType.MINUS)
         Assertions.assertEquals("1-", viewModel.mainValueText.get())
         Assertions.assertTrue(viewModel.calculating.get())
     }
@@ -122,42 +123,42 @@ class CalculatorViewModelTest {
     @Test
     fun `tapMultiple() mainValueTextが空の場合、mainValueTextが更新されないこと`() {
         viewModel.mainValueText.set("")
-        viewModel.tapMultiple()
+        viewModel.tapOperation(OperationType.MULTIPLE)
         Assertions.assertEquals("", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapMultiple() mainValueTextの末尾が小数点の場合、mainValueTextが更新されないこと`() {
         viewModel.mainValueText.set("1.")
-        viewModel.tapMultiple()
+        viewModel.tapOperation(OperationType.MULTIPLE)
         Assertions.assertEquals("1.", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapMultiple() mainValueTextが-のみの場合、mainValueTextが空に更新されること`() {
         viewModel.mainValueText.set("-")
-        viewModel.tapMultiple()
+        viewModel.tapOperation(OperationType.MULTIPLE)
         Assertions.assertEquals("", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapMultiple() mainValueTextが四則演算子の場合、mainValueTextが空に更新されること`() {
         viewModel.mainValueText.set("-")
-        viewModel.tapMultiple()
+        viewModel.tapOperation(OperationType.MULTIPLE)
         Assertions.assertEquals("", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapMultiple() mainValueTextが空の場合、末尾の四則演算子が×に入れ替わること`() {
         viewModel.mainValueText.set("1+")
-        viewModel.tapMultiple()
+        viewModel.tapOperation(OperationType.MULTIPLE)
         Assertions.assertEquals("1×", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapMultiple() 上記以外の場合、mainValueTextの末尾に×が追加されること`() {
         viewModel.mainValueText.set("1")
-        viewModel.tapMultiple()
+        viewModel.tapOperation(OperationType.MULTIPLE)
         Assertions.assertEquals("1×", viewModel.mainValueText.get())
         Assertions.assertTrue(viewModel.calculating.get())
     }
@@ -165,35 +166,35 @@ class CalculatorViewModelTest {
     @Test
     fun `tapDivide() mainValueTextの末尾が小数点の場合、mainValueTextが更新されないこと`() {
         viewModel.mainValueText.set("1.")
-        viewModel.tapDivide()
+        viewModel.tapOperation(OperationType.DIVIDE)
         Assertions.assertEquals("1.", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapDivide() mainValueTextが-のみの場合、mainValueTextが空に更新されること`() {
         viewModel.mainValueText.set("-")
-        viewModel.tapDivide()
+        viewModel.tapOperation(OperationType.DIVIDE)
         Assertions.assertEquals("", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapDivide() mainValueTextが四則演算子の場合、mainValueTextが空に更新されること`() {
         viewModel.mainValueText.set("-")
-        viewModel.tapDivide()
+        viewModel.tapOperation(OperationType.DIVIDE)
         Assertions.assertEquals("", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapDivide() mainValueTextが空の場合、末尾の四則演算子が÷に入れ替わること`() {
         viewModel.mainValueText.set("1-")
-        viewModel.tapDivide()
+        viewModel.tapOperation(OperationType.DIVIDE)
         Assertions.assertEquals("1÷", viewModel.mainValueText.get())
     }
 
     @Test
     fun `tapDivide() 上記以外の場合、mainValueTextの末尾に÷が追加されること`() {
         viewModel.mainValueText.set("1")
-        viewModel.tapDivide()
+        viewModel.tapOperation(OperationType.DIVIDE)
         Assertions.assertEquals("1÷", viewModel.mainValueText.get())
         Assertions.assertTrue(viewModel.calculating.get())
     }

--- a/app/src/test/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModelTest.kt
+++ b/app/src/test/java/com/hotatekaoru/kotlincalculator/viewmodels/CalculatorViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.hotatekaoru.kotlincalculator.viewmodel
+package com.hotatekaoru.kotlincalculator.viewmodels
 
 import org.junit.Before
 import org.junit.Test

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## 概要

Fixed #7 

現状、四則演算子の文字列を、OperationTypeクラス（Enum）と、表示用の res/strings.xml の2重管理していた。この文字列の定義をEnum側に寄せ、表示する文字列を一括管理でき、さらに、四則演算子タップ時の共通の処理を実装しやすくなるように変更した。

## 気づいたこと
`enum` というpackage名は、DataBindingで使用する際に、変数展開される。
enum 自体は予約後なので、以下のエラーメッセージが出る

```
check your module classpath for missing or conflicting dependencies
エラー: リリース5から'enum'はキーワードなので識別子として使用することはできません
('enum'を識別子として使用するには-source 1.4以前を使用してください)
```

今回は、enums というpackage名になるように修正した。合わせて、modelやviewも複数形のpackage名に修正した